### PR TITLE
Prevent e.target.classList from being undefined

### DIFF
--- a/src/directives/draggable.ts
+++ b/src/directives/draggable.ts
@@ -57,7 +57,7 @@ export class Draggable {
     dragStart(e) {
         if (this.allowDrag()) {
             if (e.target.classList != undefined && e.target.classList != null)
-				e.target.classList.add(this.dragOverClass);
+		e.target.classList.add(this.dragOverClass);
             e.dataTransfer.setData('application/json', JSON.stringify(this.dragData));
             e.dataTransfer.setData(this.dragScope, this.dragScope);
             e.stopPropagation();

--- a/src/directives/draggable.ts
+++ b/src/directives/draggable.ts
@@ -56,7 +56,8 @@ export class Draggable {
     @HostListener('dragstart', ['$event'])
     dragStart(e) {
         if (this.allowDrag()) {
-            e.target.classList.add(this.dragOverClass);
+            if (e.target.classList != undefined && e.target.classList != null)
+				e.target.classList.add(this.dragOverClass);
             e.dataTransfer.setData('application/json', JSON.stringify(this.dragData));
             e.dataTransfer.setData(this.dragScope, this.dragScope);
             e.stopPropagation();
@@ -74,7 +75,8 @@ export class Draggable {
 
     @HostListener('dragend', ['$event'])
     dragEnd(e) {
-        e.target.classList.remove(this.dragOverClass);
+        if (e.target.classList != undefined && e.target.classList != null)
+            e.target.classList.remove(this.dragOverClass);
         this.onDragEnd.emit(e);
         e.stopPropagation();
         e.preventDefault();

--- a/src/directives/droppable.ts
+++ b/src/directives/droppable.ts
@@ -1,32 +1,3 @@
-import {Directive, ElementRef, HostListener, Input, Output, EventEmitter} from '@angular/core';
-import {DropEvent} from "../shared/drop-event.model";
-
-@Directive({
-    selector: '[droppable]',
-    host: {
-        '[draggable]': 'true'
-    }
-})
-export class Droppable {
-
-    /**
-     *  Event fired when Drag dragged element enters a valid drop target.
-     */
-    @Output() onDragEnter: EventEmitter<any> = new EventEmitter();
-    
-    /**
-     * Event fired when an element is being dragged over a valid drop target  
-     */
-    @Output() onDragOver: EventEmitter<any> = new EventEmitter();
-
-    /**
-     * Event fired when a dragged element leaves a valid drop target.
-     */
-    @Output() onDragLeave: EventEmitter<any> = new EventEmitter();
-
-    /**
-     * Event fired when an element is dropped on a valid drop target.
-     */
     @Output() onDrop: EventEmitter<DropEvent> = new EventEmitter();
 
     /**
@@ -52,6 +23,7 @@ export class Droppable {
     @HostListener('dragover', ['$event'])
     dragOver(e) {
         if (this.allowDrop(e)) {
+            if (e.target.classList != undefined)
             e.target.classList.add(this.dragOverClass);
             e.preventDefault();
             this.onDragOver.emit(e);
@@ -60,14 +32,16 @@ export class Droppable {
 
     @HostListener('dragleave', ['$event'])
     dragLeave(e) {
-        e.target.classList.remove(this.dragOverClass);
+        if (e.target.classList != undefined)
+            e.target.classList.remove(this.dragOverClass);
         e.preventDefault();
         this.onDragLeave.emit(e);
     }
 
     @HostListener('drop', ['$event'])
     drop(e) {
-        e.target.classList.remove(this.dragOverClass);
+        if (e.target.classList != undefined)
+            e.target.classList.remove(this.dragOverClass);
         e.preventDefault();
         e.stopPropagation();
         let data;

--- a/src/directives/droppable.ts
+++ b/src/directives/droppable.ts
@@ -1,3 +1,32 @@
+import {Directive, ElementRef, HostListener, Input, Output, EventEmitter} from '@angular/core';
+import {DropEvent} from "../shared/drop-event.model";
+
+@Directive({
+    selector: '[droppable]',
+    host: {
+        '[draggable]': 'true'
+    }
+})
+export class Droppable {
+
+    /**
+     *  Event fired when Drag dragged element enters a valid drop target.
+     */
+    @Output() onDragEnter: EventEmitter<any> = new EventEmitter();
+    
+    /**
+     * Event fired when an element is being dragged over a valid drop target  
+     */
+    @Output() onDragOver: EventEmitter<any> = new EventEmitter();
+
+    /**
+     * Event fired when a dragged element leaves a valid drop target.
+     */
+    @Output() onDragLeave: EventEmitter<any> = new EventEmitter();
+
+    /**
+     * Event fired when an element is dropped on a valid drop target.
+     */
     @Output() onDrop: EventEmitter<DropEvent> = new EventEmitter();
 
     /**
@@ -23,8 +52,8 @@
     @HostListener('dragover', ['$event'])
     dragOver(e) {
         if (this.allowDrop(e)) {
-            if (e.target.classList != undefined)
-            e.target.classList.add(this.dragOverClass);
+            if (e.target.classList != undefined && e.target.classList != null)
+				e.target.classList.add(this.dragOverClass);
             e.preventDefault();
             this.onDragOver.emit(e);
         }
@@ -32,7 +61,7 @@
 
     @HostListener('dragleave', ['$event'])
     dragLeave(e) {
-        if (e.target.classList != undefined)
+        if (e.target.classList != undefined && e.target.classList != null)
             e.target.classList.remove(this.dragOverClass);
         e.preventDefault();
         this.onDragLeave.emit(e);
@@ -40,7 +69,7 @@
 
     @HostListener('drop', ['$event'])
     drop(e) {
-        if (e.target.classList != undefined)
+        if (e.target.classList != undefined && e.target.classList != null)
             e.target.classList.remove(this.dragOverClass);
         e.preventDefault();
         e.stopPropagation();

--- a/src/directives/droppable.ts
+++ b/src/directives/droppable.ts
@@ -53,7 +53,7 @@ export class Droppable {
     dragOver(e) {
         if (this.allowDrop(e)) {
             if (e.target.classList != undefined && e.target.classList != null)
-				e.target.classList.add(this.dragOverClass);
+		e.target.classList.add(this.dragOverClass);
             e.preventDefault();
             this.onDragOver.emit(e);
         }


### PR DESCRIPTION
Sometimes, e.target.classList is undefined for unknow reasons (not tested deeply).

Added an "if" statement to prevent code from crashing.