### PR TITLE
Removed 'dev' from 'npm install'

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The [demo folder](https://github.com/ObaidUrRehman/ng2-drag-drop/tree/master/dem
 
 # Installation
 ```js
-npm install ng2-drag-drop --save dev
+npm install ng2-drag-drop --save
 ```
 
 # Usage


### PR DESCRIPTION
Copy and paste of the command gave a string of errors on Windows 10.