### PR TITLE
fix: unable to transpile with tsc 2.3.2, node 7.10.0, npm 4.2.0

### DIFF
--- a/src/directives/droppable.ts
+++ b/src/directives/droppable.ts
@@ -126,8 +126,7 @@ export class Droppable implements OnInit, OnDestroy {
             if (typeof this.ng2DragDropService.scope === "string")
                 allowed = this.dropScope.indexOf(this.ng2DragDropService.scope) > -1;
             else if (this.ng2DragDropService.scope instanceof Array)
-                allowed = this.dropScope.filter(
-                        function (item) {
+                allowed = this.dropScope.filter(item => {
                             return this.ng2DragDropService.scope.indexOf(item) !== -1;
                         }).length > 0;
         }


### PR DESCRIPTION
THIS operator was scoped to the surrounding function expression, so it was picking up a void object when I ran npm transpile. Modified to use arrow function expression to give expression access to the ng2DragDropService on the class.