### PR TITLE
Drag handle bug fix

### DIFF
--- a/src/directives/droppable.directive.ts
+++ b/src/directives/droppable.directive.ts
@@ -87,10 +87,6 @@ export class Droppable implements OnInit, OnDestroy {
         }
     }
 
-    ngOnChanges() {
-        
-    }
-
     ngOnDestroy() {
         this.unsubscribeService();
     }


### PR DESCRIPTION
I have come across an issue with the drag handles, because the current target that is used for the drag handles is updated on mouseover and the drag start requires movement of the mouse to initiate sometimes it does not work. The tracked current target can get updated when the mouse moves off the drag handle before the drag star event fires. This can be seen on the plunkr demo if you click and drag quickly using the drag handle.