### PR TITLE
Performance improvements

### DIFF
--- a/src/directives/draggable.directive.ts
+++ b/src/directives/draggable.directive.ts
@@ -86,7 +86,7 @@ export class Draggable implements OnInit {
      * @private
      * Keeps track of mouse over element that is used to determine drag handles
      */
-    mouseOverElement: any;
+    mouseDownElement: any;
 
     /**
      * @private
@@ -154,14 +154,14 @@ export class Draggable implements OnInit {
         e.preventDefault();
     }
 
-    @HostListener('mouseover', ['$event'])
-    mouseover(e) {
-        this.mouseOverElement = e.target;
+    @HostListener('mousedown', ['$event'])
+    mousedown(e) {
+        this.mouseDownElement = e.target;
     }
 
     private allowDrag() {
         if (this.dragHandle) {
-            return DomHelper.matches(this.mouseOverElement, this.dragHandle) && this.dragEnabled;
+            return DomHelper.matches(this.mouseDownElement, this.dragHandle) && this.dragEnabled;
         } else {
             return this.dragEnabled;
         }

--- a/src/directives/draggable.directive.ts
+++ b/src/directives/draggable.directive.ts
@@ -1,4 +1,4 @@
-import { Directive, ElementRef, HostListener, Input, Output, EventEmitter, OnInit, HostBinding } from '@angular/core';
+import { Directive, ElementRef, HostListener, Input, Output, EventEmitter, OnInit, HostBinding, Renderer, NgZone, OnDestroy } from '@angular/core';
 import { Ng2DragDropService } from '../services/ng2-drag-drop.service';
 import { DomHelper } from '../shared/dom-helper';
 
@@ -8,7 +8,7 @@ import { DomHelper } from '../shared/dom-helper';
 /**
  * Makes an element draggable by adding the draggable html attribute
  */
-export class Draggable implements OnInit {
+export class Draggable implements OnInit, OnDestroy {
     /**
      * The data that will be avaliable to the droppable directive on its `onDrop()` event.
      */
@@ -106,11 +106,22 @@ export class Draggable implements OnInit {
      */
     dragImageElement: HTMLImageElement;
 
-    constructor(protected el: ElementRef, private ng2DragDropService: Ng2DragDropService) {
+    /**
+     * @private
+     * Function for unbinding the drag listener
+     */
+    unbindDragListener: Function;
+
+    constructor(protected el: ElementRef, private renderer: Renderer,
+        private ng2DragDropService: Ng2DragDropService, private zone: NgZone) {
     }
 
     ngOnInit() {
         this.applyDragHandleClass();
+    }
+
+    ngOnDestroy() {
+        this.unbindDragListeners();
     }
 
     @HostListener('dragstart', ['$event'])
@@ -135,18 +146,24 @@ export class Draggable implements OnInit {
             e.stopPropagation();
             this.onDragStart.emit(e);
             this.ng2DragDropService.onDragStart.next();
+
+            this.zone.runOutsideAngular(() => {
+                this.unbindDragListener = this.renderer.listen(this.el.nativeElement, 'drag', (dragEvent) => {
+                    this.drag(dragEvent);
+                });
+            });
         } else {
             e.preventDefault();
         }
     }
 
-    @HostListener('drag', ['$event'])
     drag(e) {
         this.onDrag.emit(e);
     }
 
     @HostListener('dragend', ['$event'])
     dragEnd(e) {
+        this.unbindDragListeners();
         DomHelper.removeClass(this.el, this.dragClass);
         this.ng2DragDropService.onDragEnd.next();
         this.onDragEnd.emit(e);
@@ -183,5 +200,11 @@ export class Draggable implements OnInit {
         }
 
         return dragElement;
+    }
+
+    unbindDragListeners() {
+        if (this.unbindDragListener) {
+            this.unbindDragListener();
+        }
     }
 }

--- a/src/directives/droppable.directive.ts
+++ b/src/directives/droppable.directive.ts
@@ -87,10 +87,6 @@ export class Droppable implements OnInit, OnDestroy {
         }
     }
 
-    ngOnChanges() {
-        
-    }
-
     ngOnDestroy() {
         this.unsubscribeService();
     }


### PR DESCRIPTION
I have updated the way that some of the browser events are bound so that the repeat firing events occur outside the angular zone. This is to prevent multiple change detection runs whilst dragging elements around. This fixes performance issues seen on pages using the drag and drop directives that also have a large amount of bound content which is refreshed on change detection.